### PR TITLE
[WIP] CARRY: Override host ethernet MTU

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -154,6 +154,7 @@ func (a *Common) Dependencies() []asset.Asset {
 		&releaseimage.Image{},
 		new(rhcos.Image),
 		&bootkube.ARODNSConfig{},
+		&bootkube.AROMTUConfig{},
 	}
 }
 
@@ -162,7 +163,8 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 	installConfig := &installconfig.InstallConfig{}
 	bootstrapSSHKeyPair := &tls.BootstrapSSHKeyPair{}
 	aroDNSConfig := &bootkube.ARODNSConfig{}
-	dependencies.Get(installConfig, bootstrapSSHKeyPair, aroDNSConfig)
+	aroMTUConfig := &bootkube.AROMTUConfig{}
+	dependencies.Get(installConfig, bootstrapSSHKeyPair, aroDNSConfig, aroMTUConfig)
 
 	a.Config = &igntypes.Config{
 		Ignition: igntypes.Ignition{
@@ -215,6 +217,10 @@ func (a *Common) generateConfig(dependencies asset.Parents, templateData *bootst
 
 	a.Config.Storage.Files = append(a.Config.Storage.Files, dnsmasqIgnConfig.Storage.Files...)
 	a.Config.Systemd.Units = append(a.Config.Systemd.Units, dnsmasqIgnConfig.Systemd.Units...)
+
+	if aroMTUConfig.MTU > 0 {
+		a.Config.Storage.Files = append(a.Config.Storage.Files, aroMTUConfig.IgnitionFile())
+	}
 
 	return nil
 }

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -88,15 +88,16 @@ func TestMasterGenerateMachineConfigs(t *testing.T) {
 		name                  string
 		key                   string
 		hyperthreading        types.HyperthreadingMode
+		mtu                   int
 		expectedMachineConfig []string
 	}{
 		{
-			name:                  "no key hyperthreading enabled",
+			name:                  "no key hyperthreading enabled default MTU",
 			hyperthreading:        types.HyperthreadingEnabled,
 			expectedMachineConfig: []string{aroDNSMasterMachineConfig},
 		},
 		{
-			name:           "key present hyperthreading enabled",
+			name:           "key present hyperthreading enabled default MTU",
 			key:            "ssh-rsa: dummy-key",
 			hyperthreading: types.HyperthreadingEnabled,
 			expectedMachineConfig: []string{`apiVersion: machineconfiguration.openshift.io/v1
@@ -123,7 +124,7 @@ spec:
 `, aroDNSMasterMachineConfig},
 		},
 		{
-			name:           "no key hyperthreading disabled",
+			name:           "no key hyperthreading disabled default MTU",
 			hyperthreading: types.HyperthreadingDisabled,
 			expectedMachineConfig: []string{`apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
@@ -153,7 +154,7 @@ spec:
 `, aroDNSMasterMachineConfig},
 		},
 		{
-			name:           "key present hyperthreading disabled",
+			name:           "key present hyperthreading disabled default MTU",
 			key:            "ssh-rsa: dummy-key",
 			hyperthreading: types.HyperthreadingDisabled,
 			expectedMachineConfig: []string{`apiVersion: machineconfiguration.openshift.io/v1
@@ -204,6 +205,39 @@ spec:
   osImageURL: ""
 `, aroDNSMasterMachineConfig},
 		},
+		{
+			name:           "no key hyperthreading enabled custom MTU",
+			hyperthreading: types.HyperthreadingEnabled,
+			mtu:            1500,
+			expectedMachineConfig: []string{
+				aroDNSMasterMachineConfig,
+				`apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-mtu
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKaWYgWyAiJDEiID09ICJldGgwIiBdICYmIFsgIiQyIiA9PSAidXAiIF07IHRoZW4KICAgIGlwIGxpbmsgc2V0ICQxIG10dSAxNTAwCmZp
+        mode: 365
+        overwrite: true
+        path: /etc/NetworkManager/dispatcher.d/30-eth0-mtu-3900
+        user:
+          name: root
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""
+`},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -245,6 +279,7 @@ spec:
 					},
 				},
 				&bootkube.ARODNSConfig{},
+				&bootkube.AROMTUConfig{MTU: tc.mtu},
 			)
 			master := &Master{}
 			if err := master.Generate(parents); err != nil {
@@ -305,6 +340,7 @@ func TestControlPlaneIsNotModified(t *testing.T) {
 			},
 		},
 		&bootkube.ARODNSConfig{},
+		&bootkube.AROMTUConfig{},
 	)
 	master := &Master{}
 	if err := master.Generate(parents); err != nil {

--- a/pkg/asset/templates/content/bootkube/aro-mtu-config.go
+++ b/pkg/asset/templates/content/bootkube/aro-mtu-config.go
@@ -1,0 +1,91 @@
+package bootkube
+
+import (
+	"fmt"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
+)
+
+const (
+	ignFilePath = "/etc/NetworkManager/dispatcher.d/30-eth0-mtu-3900"
+	ignFileData = `#!/bin/bash
+if [ "$1" == "eth0" ] && [ "$2" == "up" ]; then
+    ip link set $1 mtu %d
+fi`
+)
+
+var _ asset.WritableAsset = (*AROMTUConfig)(nil)
+
+// AROMTUConfig overrides the eth0 device MTU on nodes
+type AROMTUConfig struct {
+	MTU int
+}
+
+// Dependencies returns all of the dependencies directly needed by the asset
+func (c *AROMTUConfig) Dependencies() []asset.Asset {
+	return nil
+}
+
+// Name returns the human-friendly name of the asset
+func (c *AROMTUConfig) Name() string {
+	return "AROMTUConfig"
+}
+
+// Generate generates the actual files by this asset
+func (c *AROMTUConfig) Generate(parents asset.Parents) error {
+	return nil
+}
+
+func (c *AROMTUConfig) Files() []*asset.File {
+	return nil
+}
+
+// Load returns the asset from disk
+func (c *AROMTUConfig) Load(f asset.FileFetcher) (bool, error) {
+	return true, nil
+}
+
+// Generates a file for an ignition config
+func (c *AROMTUConfig) IgnitionFile() igntypes.File {
+	return ignition.FileFromString(ignFilePath, "root", 0555, fmt.Sprintf(ignFileData, c.MTU))
+}
+
+// Generates a MachineConfig for the given role
+func (c *AROMTUConfig) MachineConfig(role string) (*mcfgv1.MachineConfig, error) {
+	ignConfig := igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: igntypes.MaxVersion.String(),
+		},
+		Storage: igntypes.Storage{
+			Files: []igntypes.File{
+				c.IgnitionFile(),
+			},
+		},
+	}
+
+	rawExt, err := ignition.ConvertToRawExtension(ignConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcfgv1.SchemeGroupVersion.String(),
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-mtu", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: rawExt,
+		},
+	}, nil
+}


### PR DESCRIPTION
To support Azure's increased MTU, despite DHCP still supplying the same default 1500 MTU to virtual machines.

`AROMTUConfig.MTU` value must be set by ARO-RP prior to resolving the install graph.

---
**NOTE:**
This is a reimplementation of https://github.com/Azure/ARO-RP/pull/1672, with most of the logic moved to the installer.
Marked WIP while testing with ARO-RP, but unit tests pass and the code can be reviewed.
