### PR TITLE
Boostrap mdsd hostname 4.11

### DIFF
--- a/data/data/bootstrap/systemd/units/mdsd.service
+++ b/data/data/bootstrap/systemd/units/mdsd.service
@@ -11,7 +11,6 @@ ExecStartPre=-/bin/podman pull $MDSDIMAGE
 ExecStart=/bin/podman run \
   --entrypoint /usr/sbin/mdsd \
   --net=host \
-  --hostname `hostname` \
   --name mdsd \
   --env-file /etc/mdsd.d/mdsd.env \
   --rm \


### PR DESCRIPTION
Based on discussion in https://github.com/openshift/installer/pull/7600#discussion_r1379588682 and https://redhat-internal.slack.com/archives/C02ULBRS68M/p1699643403392589, trying to set the container hostname in this way results in the container hostname being the literal string `` `hostname` ``, since systemd doesn't do any shell expansion of ExecStart parameters. This is not needed anyway, since mdsd is using `MONITORING_ROLE_INSTANCE=bootstrap` from the env file instead.